### PR TITLE
feat: highlight inactive probes and hubs

### DIFF
--- a/extension-chrome/scripts/sondes.js
+++ b/extension-chrome/scripts/sondes.js
@@ -116,20 +116,39 @@ function verifierSondesListe(ids) {
               .then((data) => {
                 if (isHub) {
                   const row = data?.Result?.Rows?.[0];
-                  const emoji = row ? "✅" : "❌";
-                  const info = row
-                    ? ` (${row.ConnectionStatus}, ${row.Status}, ${row.LastRequestAt || "-"})`
-                    : "";
-                  updatedLines.push(`${cleanId} ${emoji}${info}`);
+                  if (row) {
+                    const lastReq = row.LastRequestAt
+                      ? new Date(row.LastRequestAt)
+                      : null;
+                    const recent =
+                      lastReq && Date.now() - lastReq.getTime() < 3600 * 1000;
+                    const connected =
+                      row.ConnectionStatus?.toLowerCase() === "connected";
+                    const emoji = connected && recent ? "✅" : "❌";
+                    const info = ` (${row.ConnectionStatus}, ${row.Status}, ${
+                      row.LastRequestAt || "-"
+                    })`;
+                    updatedLines.push(`${cleanId} ${emoji}${info}`);
+                  } else {
+                    updatedLines.push(`${cleanId} ❌`);
+                  }
                 } else {
                   const row = data?.Result?.Rows?.[0];
-                  const emoji = row ? "✅" : "❌";
-                  const temp = row?.Temperature?.Value || "?";
-                  const battery = row?.Battery || "-";
-                  const info = row
-                    ? ` (Temp: ${temp}, Battery: ${battery})`
-                    : "";
-                  updatedLines.push(`${cleanId} ${emoji}${info}`);
+                  if (row) {
+                    const timeStr = row.Time;
+                    const lastTime = timeStr ? new Date(timeStr) : null;
+                    const recent =
+                      lastTime && Date.now() - lastTime.getTime() < 3600 * 1000;
+                    const emoji = recent ? "✅" : "❌";
+                    const temp = row?.Temperature?.Value || "?";
+                    const battery = row?.Battery || "-";
+                    const info = ` (Temp: ${temp}, Battery: ${battery}, Time: ${
+                      timeStr || "-"
+                    })`;
+                    updatedLines.push(`${cleanId} ${emoji}${info}`);
+                  } else {
+                    updatedLines.push(`${cleanId} ❌`);
+                  }
                 }
               })
               .catch(() => {


### PR DESCRIPTION
## Summary
- mark hubs disconnected or inactive for over an hour with a red cross
- show last connection time for probes and mark them inactive when stale

## Testing
- `node --check extension-chrome/scripts/sondes.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689347fd6894832fa435b44513940cb8