### PR TITLE
Preserve order of scanned probes and hubs

### DIFF
--- a/extension-chrome/scripts/sondes.js
+++ b/extension-chrome/scripts/sondes.js
@@ -95,12 +95,12 @@ function verifierSondesListe(ids) {
         const cleaned = ids.map((line) =>
           line.split(" ")[0].trim().replace(/\s+/g, ""),
         );
-        const updatedLines = [];
+        const updatedLines = Array(cleaned.length);
 
         Promise.all(
-          cleaned.map((cleanId) => {
+          cleaned.map((cleanId, idx) => {
             if (!cleanId) {
-              updatedLines.push("");
+              updatedLines[idx] = "";
               return Promise.resolve();
             }
 
@@ -128,9 +128,9 @@ function verifierSondesListe(ids) {
                     const info = ` (${row.ConnectionStatus}, ${row.Status}, ${
                       row.LastRequestAt || "-"
                     })`;
-                    updatedLines.push(`${cleanId} ${emoji}${info}`);
+                    updatedLines[idx] = `${cleanId} ${emoji}${info}`;
                   } else {
-                    updatedLines.push(`${cleanId} ❌`);
+                    updatedLines[idx] = `${cleanId} ❌`;
                   }
                 } else {
                   const row = data?.Result?.Rows?.[0];
@@ -147,18 +147,18 @@ function verifierSondesListe(ids) {
                     const info = ` (Temp: ${temp}, Battery: ${battery}, Time: ${
                       timeStr || "-"
                     })`;
-                    updatedLines.push(`${cleanId} ${emoji}${info}`);
+                    updatedLines[idx] = `${cleanId} ${emoji}${info}`;
                   } else {
-                    updatedLines.push(`${cleanId} ❌`);
+                    updatedLines[idx] = `${cleanId} ❌`;
                   }
                 }
               })
               .catch(() => {
-                updatedLines.push(`${cleanId} ❌`);
+                updatedLines[idx] = `${cleanId} ❌`;
               });
           }),
         ).then(() => {
-          resolve(updatedLines.filter(Boolean));
+          resolve(updatedLines);
         });
       },
     );


### PR DESCRIPTION
## Summary
- Keep sensor/hub verification results in the original order
- Return all entries, including blanks, without filtering

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b323a96b4832f88556f40f742c1cd