### PR TITLE
Auto-resize probe textarea and separate results

### DIFF
--- a/extension-chrome/popup.css
+++ b/extension-chrome/popup.css
@@ -180,6 +180,7 @@ h2 {
   font-size: 13px;
   margin: 10px 0;
   resize: vertical;
+  overflow-y: hidden;
 }
 
 #verifierSondes {

--- a/extension-chrome/popup.js
+++ b/extension-chrome/popup.js
@@ -33,6 +33,11 @@ function keysMatch(a, b) {
   return a === b || a.startsWith(b) || b.startsWith(a);
 }
 
+function autoResizeTextarea(el) {
+  el.style.height = "auto";
+  el.style.height = `${el.scrollHeight}px`;
+}
+
 function getBOSSID(callback) {
   chrome.cookies.get(
     { url: "https://backoffice.epack-manager.com", name: "BOSSID" },
@@ -235,6 +240,8 @@ document.getElementById("toggleLogin").addEventListener("click", () => {
 
 // 🔐 Charger les infos au démarrage
 document.addEventListener("DOMContentLoaded", () => {
+  const sondeTextarea = document.getElementById("sonde-ids");
+  sondeTextarea.addEventListener("input", () => autoResizeTextarea(sondeTextarea));
   chrome.storage.local.get(
     ["probeEmail", "probePassword", "proxyURL", "sondeIds", "lastSondeResults"],
     (data) => {
@@ -252,10 +259,11 @@ document.addEventListener("DOMContentLoaded", () => {
       }
 
       if (Array.isArray(data.sondeIds)) {
-        document.getElementById("sonde-ids").value = data.lastSondeResults
-          ? data.lastSondeResults.join("\n")
+        sondeTextarea.value = data.lastSondeResults
+          ? data.lastSondeResults.join("\n---\n")
           : data.sondeIds.join("\n");
       }
+      autoResizeTextarea(sondeTextarea);
     },
   );
 });
@@ -323,7 +331,10 @@ document.getElementById("testConnexion").addEventListener("click", () => {
 });
 
 document.getElementById("verifierSondes").addEventListener("click", () => {
-  const ids = document.getElementById("sonde-ids").value.split("\n");
+  const ids = document
+    .getElementById("sonde-ids")
+    .value.split("\n")
+    .filter((line) => line.trim() && !/^[-]{3,}$/.test(line.trim()));
   chrome.storage.local.set({ sondeIds: ids }, () => {
     sondeUtils.verifierSondes();
   });

--- a/extension-chrome/scripts/sondes.js
+++ b/extension-chrome/scripts/sondes.js
@@ -168,13 +168,17 @@ function verifierSondesListe(ids) {
 // Vérifie les sondes depuis le textarea du popup
 function verifierSondes() {
   const textarea = document.getElementById("sonde-ids");
-  const rawLines = textarea.value.split("\n");
+  const rawLines = textarea.value
+    .split("\n")
+    .filter((line) => line.trim() && !/^[-]{3,}$/.test(line.trim()));
   if (rawLines.length === 0) {
     updateSondeOutput("Veuillez entrer au moins un ID.", "error");
     return;
   }
   verifierSondesListe(rawLines).then((result) => {
-    textarea.value = result.join("\n");
+    textarea.value = result.join("\n---\n");
+    chrome.storage.local.set({ lastSondeResults: result });
+    textarea.dispatchEvent(new Event("input"));
   });
 }
 


### PR DESCRIPTION
## Summary
- auto-resize the probe ID textarea
- insert dashed separators between probe/hub results

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b34b83d40832fad1cc14c725dd5ad