### PR TITLE
fix user existence check

### DIFF
--- a/extension-chrome/scripts/tasks.js
+++ b/extension-chrome/scripts/tasks.js
@@ -253,7 +253,9 @@ async function checkIfUserExists(email) {
   try {
     const response = await fetch(url, { method: 'GET', credentials: 'include' });
     const html = await response.text();
-    const match = html.match(/<table[^>]*class="table-bordered"[^>]*>[\s\S]*?<tbody[^>]*>[\s\S]*?<tr[^>]*>[\s\S]*?<td>(\d+)<\/td>/i);
+    const match = html.match(
+      /<table[^>]*class="[^"]*table-bordered[^"]*"[^>]*>[\s\S]*?<tbody[^>]*>[\s\S]*?<tr[^>]*>[\s\S]*?<td>(\d+)<\/td/i
+    );
     return match ? match[1] : null;
   } catch {
     return null;


### PR DESCRIPTION
## Summary
- ensure user search parsing finds existing user to avoid duplicates

## Testing
- `npm test` (fails: ENOENT package.json)
- `cd reverseproxy && npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68b9cd9b6d28832fa417866b0652e9ff