### PR TITLE
feat: migrate extension to manifest v3

### DIFF
--- a/extension-chrome/README.md
+++ b/extension-chrome/README.md
@@ -1,8 +1,8 @@
 # Extension Chrome ePack Tools
 
-Cette extension automatise plusieurs tâches réalisées dans le backoffice
-`backoffice.epack-manager.com` à partir des données collectées sur Odoo.
-Elle permet notamment :
+Cette extension basée sur le **manifest v3** automatise plusieurs tâches
+réalisées dans le backoffice `backoffice.epack-manager.com` à partir des
+données collectées sur Odoo. Elle permet notamment :
 
 - création automatique de **solutions** et d'**utilisateurs** ;
 - ouverture rapide des **paramètres** liés à une zone ;

--- a/extension-chrome/manifest.json
+++ b/extension-chrome/manifest.json
@@ -4,8 +4,6 @@
   "version": "1.0",
   "description": "Une extension pour gérer les solutions/utilisateurs sur backoffice.epack-manager.com.",
   "permissions": [
-    "webRequest",
-    "webRequestBlocking",
     "scripting",
     "activeTab",
     "storage",
@@ -41,6 +39,11 @@
       ],
       "js": ["scripts/solution-copy.js"],
       "run_at": "document_idle"
+    },
+    {
+      "matches": ["https://chr-num.odoo.com/*"],
+      "js": ["scripts/request-interceptor.js"],
+      "run_at": "document_start"
     }
   ],
   "action": {

--- a/extension-chrome/scripts/request-interceptor.js
+++ b/extension-chrome/scripts/request-interceptor.js
@@ -1,0 +1,56 @@
+(function () {
+  function handleRequest(url, body) {
+    if (typeof url !== 'string' || typeof body !== 'string') return;
+    if (url.includes('sale.order/read')) {
+      chrome.runtime.sendMessage({ type: 'saleOrderRead', body });
+    } else if (url.includes('mail/thread/data')) {
+      chrome.runtime.sendMessage({ type: 'mailThreadData', body });
+    }
+  }
+
+  function interceptFetch() {
+    const originalFetch = window.fetch;
+    window.fetch = function(input, init = {}) {
+      try {
+        const url = typeof input === 'string' ? input : input.url;
+        const method = (init && init.method) || 'GET';
+        const body = init && init.body;
+        if (method === 'POST' && body) {
+          if (typeof body === 'string') {
+            handleRequest(url, body);
+          } else if (body instanceof URLSearchParams) {
+            handleRequest(url, body.toString());
+          }
+        }
+      } catch (e) {
+        // ignore errors
+      }
+      return originalFetch.apply(this, arguments);
+    };
+  }
+
+  function interceptXHR() {
+    const originalOpen = XMLHttpRequest.prototype.open;
+    const originalSend = XMLHttpRequest.prototype.send;
+
+    XMLHttpRequest.prototype.open = function(method, url) {
+      this._method = method;
+      this._url = url;
+      return originalOpen.apply(this, arguments);
+    };
+
+    XMLHttpRequest.prototype.send = function(body) {
+      try {
+        if (this._method === 'POST' && typeof body === 'string') {
+          handleRequest(this._url, body);
+        }
+      } catch (e) {
+        // ignore
+      }
+      return originalSend.apply(this, arguments);
+    };
+  }
+
+  interceptFetch();
+  interceptXHR();
+})();


### PR DESCRIPTION
## Summary
- replace deprecated webRequest blocking usage by request interception via content scripts
- remove webRequest permissions and register new interceptor script for Odoo domain
- document manifest v3 usage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d6d96d80832f8a2db23938ac0c13