### PR TITLE
fix: update chrome extension to manifest v3

### DIFF
--- a/extension-chrome/README.md
+++ b/extension-chrome/README.md
@@ -13,6 +13,7 @@ La collecte des données (client, manager, paramètres) se fait en arrière‑pl
 par interception des requêtes réseau envoyées par Odoo lors de la
 consultation d'un devis. Les informations sont stockées dans `chrome.storage` et
 présentées dans la fenêtre popup de l'extension.
+Cette interception est réalisée en surchargeant `fetch` et `XMLHttpRequest` côté page, ce qui évite d'avoir besoin des permissions `webRequest` et `webRequestBlocking`.
 
 ## Installation
 

--- a/extension-chrome/manifest.json
+++ b/extension-chrome/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "ePack Manager Creator",
   "version": "1.0",
   "description": "Une extension pour gérer les solutions/utilisateurs sur backoffice.epack-manager.com.",
@@ -9,18 +9,22 @@
     "cookies",
     "tabs",
     "alarms",
-    "notifications",
-    "webRequest",
-    "webRequestBlocking",
+    "notifications"
+  ],
+  "host_permissions": [
     "http://localhost:3000/*",
     "https://api.bluconsole.com/*",
     "https://backoffice.epack-manager.com/*",
     "https://chr-num.odoo.com/*"
   ],
-  "web_accessible_resources": ["sondes.html"],
+  "web_accessible_resources": [
+    {
+      "resources": ["sondes.html"],
+      "matches": ["<all_urls>"]
+    }
+  ],
   "background": {
-    "scripts": ["background.js"],
-    "persistent": true
+    "service_worker": "background.js"
   },
   "icons": {
     "16": "icons/icon16.png",
@@ -41,7 +45,7 @@
       "run_at": "document_start"
     }
   ],
-  "browser_action": {
+  "action": {
     "default_popup": "popup.html"
   }
 }


### PR DESCRIPTION
## Summary
- migrate Chrome extension manifest to version 3
- switch background script to service worker and replace browser_action with action
- split host permissions and update web accessible resources format
- document request interception via fetch/XMLHttpRequest to avoid webRequest permissions

## Testing
- `rg webRequest`
- `npm test` *(fails: ENOENT, package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b9dbe7e298832fbfef3dd598999007