### PR TITLE
Simplify sonde stock output formatting

### DIFF
--- a/extension-chrome/scripts/sondes.js
+++ b/extension-chrome/scripts/sondes.js
@@ -217,7 +217,7 @@ function recupererStockSondes() {
             return (
               `${res.serial} 📦 ` +
               res.quants
-                .map((q) => `${q.locationName} — ${q.productName} (Qty: ${q.quantity})`)
+                .map((q) => q.locationName)
                 .join(" | ")
             );
           case "no_stock":


### PR DESCRIPTION
## Summary
- remove product name and quantity from sonde stock display so only the location is shown

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d672f8dd28832fbe2fc66cc6df523d