### PR TITLE
Affiche uniquement la dernière zone de stock

### DIFF
--- a/extension-chrome/scripts/sondes.js
+++ b/extension-chrome/scripts/sondes.js
@@ -214,12 +214,12 @@ function recupererStockSondes() {
       const formatted = results.map((res) => {
         switch (res.status) {
           case "ok":
-            return (
-              `${res.serial} 📦 ` +
-              res.quants
-                .map((q) => q.locationName)
-                .join(" | ")
-            );
+            if (res.quants && res.quants.length > 0) {
+              const last = res.quants[res.quants.length - 1];
+              return `${res.serial} 📦 ${last.locationName}`;
+            } else {
+              return `${res.serial} ⚠️ Stock introuvable`;
+            }
           case "no_stock":
             return `${res.serial} ⚠️ Aucun stock disponible`;
           case "not_found":


### PR DESCRIPTION
## Summary
- affiche uniquement la dernière localisation de stock pour chaque sonde
- ajoute un message explicite lorsque la dernière localisation est introuvable

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6774780fc832fa6acdc82988f46b8